### PR TITLE
Set text as post contents

### DIFF
--- a/js/extended_injection.js
+++ b/js/extended_injection.js
@@ -111,21 +111,39 @@ Injection.prototype.parseURL = function(dom) {
   var link = parent.querySelector('a[target="_blank"]');
   var text = '';
   var title = parent.querySelector(Injection.STREAM_AUTHOR_ID);
+
+  var postContent = dom.parentNode.previousSibling.cloneNode(true);
+  var tmp = postContent.querySelectorAll("span[class]");
+  if (tmp && tmp.length)
+  {
+      var editLink = tmp[tmp.length - 1];
+      editLink.parentNode.removeChild(editLink);
+  }
+
   if (title) {
     title = title.innerText + ' @ Google+';
   }
   if (link) {
-    text = parent.querySelector(Injection.STREAM_ARTICLE_ID);
-    if (text) {
-      text = text.innerText;
+    if (postContent.innerText.replace(/\s+/g, '')) {
+      // prevent huge querystring
+      // addthis trims automatically to fit on twitter
+      text = postContent.innerText.substring(0, 800);
     }
     else {
-      text = ''; // Empty for now till we figure out what to do.
+        text = parent.querySelector(Injection.STREAM_ARTICLE_ID);
+        if (text) {
+          text = text.innerText;
+        }
+        else {
+          text = ''; // Empty for now till we figure out what to do.
+        }
     }
     link = link.href;
     // Support multiple accounts.
     link = link.replace(/plus\.google\.com\/u\/(\d*)/, 'plus.google.com');
   }
+
+  console.log(text);
   return {
     status: link ? true : false,
     link: link,

--- a/js/extended_shares.js
+++ b/js/extended_shares.js
@@ -114,7 +114,7 @@ Shares = {
   addthis: {
     name: 'Add This',
     icon: '/img/addthis.png',
-    url: 'http://www.addthis.com/bookmark.php?url=${link}&title=${title}',
+    url: 'http://www.addthis.com/bookmark.php?url=${link}&title=${text}',
     trim: false
   }
 };


### PR DESCRIPTION
On the parseURL function I added a method to retrieve the post contents. I kept your code as a fallback.

And I changed the config file to send {text} to addthis url. Addthis automatically trims the text and shorten urls.
