### PR TITLE
Livejournal 'support'

### DIFF
--- a/js/extended_shares.js
+++ b/js/extended_shares.js
@@ -116,5 +116,11 @@ Shares = {
     icon: '/img/addthis.png',
     url: 'http://www.addthis.com/bookmark.php?url=${link}&title=${text}',
     trim: false
+  },
+  livejournal: {
+    name: 'Live Journal',
+    icon: '/img/lj.png',
+    url: 'http://www.livejournal.com/update.bml/?event=${text}<a href="${link}">${title}</a>&subject=${title}',
+    trim: false
   }
 };


### PR DESCRIPTION
Added a uri to support posting to LJ. Theoretically, the same uri will work on any of the other instances of livejournal that exist.

I'm uncertain where to acquire an icon, so there's a dangling link pointed at /img/lj.png.

Also I have no idea how to assemble this to feed it to Chrome, so I've only tested that the (hopefully) constructed uri behaves as expected.
